### PR TITLE
プリセットデータのライセンス境界を明記する

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -3,6 +3,13 @@
 This file summarizes the third-party software and bundled font assets included in
 this repository.
 
+For this repository's own licensing terms, see:
+
+- `LICENSE` for the MIT-licensed application source code and project
+  documentation
+- `docs/licensing.md` for the separate CC BY 4.0 preset data notice
+- `src/data/presets/README.md` for the preset data attribution requirements
+
 ## Runtime Dependencies
 
 ### Three.js

--- a/README.md
+++ b/README.md
@@ -165,8 +165,15 @@ npm run test:e2e
 
 ## ライセンス
 
-このプロジェクト自体は [MIT License](./LICENSE) で提供します。
+アプリケーション本体とプロジェクト文書は [MIT License](./LICENSE) で提供します。
 
+`src/data/presets/` 配下のプリセットデータは
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) で提供します。
+流用・改変する場合は、各プリセットの `metadata.fullReference` または
+[Preset References](./reference.md) にある出典表記を引き継いでください。
+Sekiei / Wfrm-Qz への帰属表示は任意です。
+
+詳しいライセンス境界は [Licensing](./docs/licensing.md) にあります。
 第三者依存と bundled font のライセンス整理は [LICENSES.md](./LICENSES.md) にあります。
 
 ## 補足

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@
   - built-in preset データの出典一覧
 - [Project License](../LICENSE)
   - このプロジェクト自体のライセンス（MIT）
+- [Licensing](./licensing.md)
+  - アプリ本体とプリセットデータのライセンス境界
 - [Architecture](./architecture.md)
   - 現在のソース構成と責務分担
 - [JSON Format](./json-format.md)

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -126,3 +126,8 @@ wrapper の `preview` には次が入ります。
 ## Practical Tip
 
 公開リポジトリに preset を追加したい場合は、まずアプリから JSON 保存したものをベースにするのが一番安全です。その JSON を `src/data/presets/` に置き、必要な metadata を整える流れを推奨します。
+
+`src/data/presets/` 配下の built-in preset data は CC BY 4.0 で提供します。
+流用・改変時は、各 preset の `metadata.fullReference` または
+[`reference.md`](../reference.md) にある出典表記を引き継いでください。
+Sekiei / Wfrm-Qz への帰属表示は任意です。

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,36 @@
+# Licensing
+
+Sekiei uses separate licenses for the application source code and the bundled
+preset data.
+
+## Source Code
+
+The application source code and project documentation are licensed under the
+[MIT License](../LICENSE), except where another license is explicitly noted.
+
+## Preset Data
+
+The bundled preset data under [`src/data/presets/`](../src/data/presets/) is
+licensed under the
+[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+This applies to Sekiei's curated preset dataset as arranged and expressed in
+the JSON files. It does not claim new rights over natural facts, factual
+measurements, or third-party source materials.
+
+When reusing or modifying preset data, retain the source reference information
+for each reused preset. The reference information is provided in:
+
+- each preset's `parameters.metadata.fullReference`
+- [`reference.md`](../reference.md)
+
+Attribution to Sekiei or Wfrm-Qz is appreciated, but not required. The required
+attribution is the preservation of the per-preset source references.
+
+If you modify preset data, indicate that the data was changed where reasonably
+practicable.
+
+## Third-Party Materials
+
+Third-party software, bundled fonts, and bundled font license texts are listed
+in [`LICENSES.md`](../LICENSES.md).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sekiei",
   "private": true,
-  "license": "MIT",
+  "license": "MIT AND CC-BY-4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/data/presets/README.md
+++ b/src/data/presets/README.md
@@ -1,0 +1,20 @@
+# Preset Data License
+
+The JSON preset files in this directory are licensed under the
+[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+This license notice applies to Sekiei's curated preset dataset as arranged and
+expressed in these JSON files. It does not claim new rights over natural facts,
+factual measurements, or third-party source materials.
+
+When reusing or modifying preset data, retain the source reference information
+for each reused preset. The reference information is provided in:
+
+- each preset's `parameters.metadata.fullReference`
+- [`../../../reference.md`](../../../reference.md)
+
+Attribution to Sekiei or Wfrm-Qz is appreciated, but not required. The required
+attribution is the preservation of the per-preset source references.
+
+If you modify preset data, indicate that the data was changed where reasonably
+practicable.

--- a/tests/unit/data/licenses.test.ts
+++ b/tests/unit/data/licenses.test.ts
@@ -12,10 +12,33 @@ function readJson(path: string) {
 }
 
 describe("third-party license inventory", () => {
-  it("declares the project license as MIT and keeps a root LICENSE file", () => {
+  it("declares the package license expression and keeps project license files", () => {
     const packageJson = readJson(PACKAGE_JSON_PATH);
-    expect(packageJson.license).toBe("MIT");
+    expect(packageJson.license).toBe("MIT AND CC-BY-4.0");
     expect(existsSync(resolve(ROOT_DIR, "LICENSE"))).toBe(true);
+    expect(existsSync(resolve(ROOT_DIR, "docs/licensing.md"))).toBe(true);
+    expect(existsSync(resolve(ROOT_DIR, "src/data/presets/README.md"))).toBe(
+      true,
+    );
+  });
+
+  it("documents preset data attribution through source references", () => {
+    const presetLicense = readFileSync(
+      resolve(ROOT_DIR, "src/data/presets/README.md"),
+      "utf8",
+    );
+    const licensingDoc = readFileSync(
+      resolve(ROOT_DIR, "docs/licensing.md"),
+      "utf8",
+    );
+
+    [presetLicense, licensingDoc].forEach((text) => {
+      expect(text).toContain("Creative Commons Attribution 4.0");
+      expect(text).toContain("parameters.metadata.fullReference");
+      expect(text).toContain("reference.md");
+      expect(text).toContain("Attribution to Sekiei or Wfrm-Qz is appreciated");
+      expect(text).toContain("not required");
+    });
   });
 
   it("tracks expected licenses for direct runtime dependencies", () => {


### PR DESCRIPTION
## 概要

- アプリ本体・プロジェクト文書は MIT、`src/data/presets/` のプリセットデータは CC BY 4.0 としてライセンス境界を明記しました。
- プリセットデータ流用・改変時に必須なのは、Sekiei / Wfrm-Qz への帰属表示ではなく、各プリセットの `metadata.fullReference` または `reference.md` の出典表記を引き継ぐことだと整理しました。
- ライセンス文書と出典継承の記載を unit test で固定しました。

## 確認

- `npm run test:unit -- tests/unit/data/licenses.test.ts`
- `npm run lint:changed`
- `npm run public:check`
- push時 pre-push の `public:check`
- issue branch の GitHub Actions `CI` 成功

Closes #3