### PR TITLE
developの運用・ライセンス文書更新をmasterへ反映する

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -3,6 +3,13 @@
 This file summarizes the third-party software and bundled font assets included in
 this repository.
 
+For this repository's own licensing terms, see:
+
+- `LICENSE` for the MIT-licensed application source code and project
+  documentation
+- `docs/licensing.md` for the separate CC BY 4.0 preset data notice
+- `src/data/presets/README.md` for the preset data attribution requirements
+
 ## Runtime Dependencies
 
 ### Three.js

--- a/README.md
+++ b/README.md
@@ -165,8 +165,15 @@ npm run test:e2e
 
 ## ライセンス
 
-このプロジェクト自体は [MIT License](./LICENSE) で提供します。
+アプリケーション本体とプロジェクト文書は [MIT License](./LICENSE) で提供します。
 
+`src/data/presets/` 配下のプリセットデータは
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) で提供します。
+流用・改変する場合は、各プリセットの `metadata.fullReference` または
+[Preset References](./reference.md) にある出典表記を引き継いでください。
+Sekiei / Wfrm-Qz への帰属表示は任意です。
+
+詳しいライセンス境界は [Licensing](./docs/licensing.md) にあります。
 第三者依存と bundled font のライセンス整理は [LICENSES.md](./LICENSES.md) にあります。
 
 ## 補足

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@
   - built-in preset データの出典一覧
 - [Project License](../LICENSE)
   - このプロジェクト自体のライセンス（MIT）
+- [Licensing](./licensing.md)
+  - アプリ本体とプリセットデータのライセンス境界
 - [Architecture](./architecture.md)
   - 現在のソース構成と責務分担
 - [JSON Format](./json-format.md)

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -126,3 +126,8 @@ wrapper の `preview` には次が入ります。
 ## Practical Tip
 
 公開リポジトリに preset を追加したい場合は、まずアプリから JSON 保存したものをベースにするのが一番安全です。その JSON を `src/data/presets/` に置き、必要な metadata を整える流れを推奨します。
+
+`src/data/presets/` 配下の built-in preset data は CC BY 4.0 で提供します。
+流用・改変時は、各 preset の `metadata.fullReference` または
+[`reference.md`](../reference.md) にある出典表記を引き継いでください。
+Sekiei / Wfrm-Qz への帰属表示は任意です。

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,36 @@
+# Licensing
+
+Sekiei uses separate licenses for the application source code and the bundled
+preset data.
+
+## Source Code
+
+The application source code and project documentation are licensed under the
+[MIT License](../LICENSE), except where another license is explicitly noted.
+
+## Preset Data
+
+The bundled preset data under [`src/data/presets/`](../src/data/presets/) is
+licensed under the
+[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+This applies to Sekiei's curated preset dataset as arranged and expressed in
+the JSON files. It does not claim new rights over natural facts, factual
+measurements, or third-party source materials.
+
+When reusing or modifying preset data, retain the source reference information
+for each reused preset. The reference information is provided in:
+
+- each preset's `parameters.metadata.fullReference`
+- [`reference.md`](../reference.md)
+
+Attribution to Sekiei or Wfrm-Qz is appreciated, but not required. The required
+attribution is the preservation of the per-preset source references.
+
+If you modify preset data, indicate that the data was changed where reasonably
+practicable.
+
+## Third-Party Materials
+
+Third-party software, bundled fonts, and bundled font license texts are listed
+in [`LICENSES.md`](../LICENSES.md).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sekiei",
   "private": true,
-  "license": "MIT",
+  "license": "MIT AND CC-BY-4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/check-rulesets.mjs
+++ b/scripts/check-rulesets.mjs
@@ -5,9 +5,9 @@ import { fileURLToPath, URL } from "node:url";
 const repo = process.env.GITHUB_REPOSITORY;
 const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 const apiBaseUrl = process.env.GITHUB_API_URL || "https://api.github.com";
-const rulesetDirectory = fileURLToPath(
-  new URL("../.github/rulesets/", import.meta.url),
-);
+const currentFilePath = import.meta.url.startsWith("file:")
+  ? fileURLToPath(import.meta.url)
+  : "";
 
 function fail(message) {
   console.error(`[ruleset-check] ${message}`);
@@ -20,7 +20,7 @@ function sortByJson(values) {
   );
 }
 
-function normalizeRequiredStatusCheck(check) {
+export function normalizeRequiredStatusCheck(check) {
   const normalized = { context: check.context };
   if (check.integration_id != null) {
     normalized.integration_id = check.integration_id;
@@ -28,13 +28,24 @@ function normalizeRequiredStatusCheck(check) {
   return normalized;
 }
 
-function normalizeRule(rule) {
+export function normalizeRule(rule) {
   const normalized = { type: rule.type };
   if (!rule.parameters) {
     return normalized;
   }
 
   normalized.parameters = { ...rule.parameters };
+  if (
+    Array.isArray(normalized.parameters.required_reviewers) &&
+    normalized.parameters.required_reviewers.length === 0
+  ) {
+    delete normalized.parameters.required_reviewers;
+  }
+  if (Array.isArray(normalized.parameters.required_reviewers)) {
+    normalized.parameters.required_reviewers = sortByJson(
+      normalized.parameters.required_reviewers,
+    );
+  }
   if (Array.isArray(normalized.parameters.allowed_merge_methods)) {
     normalized.parameters.allowed_merge_methods = [
       ...normalized.parameters.allowed_merge_methods,
@@ -50,7 +61,7 @@ function normalizeRule(rule) {
   return normalized;
 }
 
-function normalizeRuleset(ruleset) {
+export function normalizeRuleset(ruleset) {
   return {
     name: ruleset.name,
     target: ruleset.target,
@@ -72,7 +83,12 @@ function normalizeRuleset(ruleset) {
   };
 }
 
-function readLocalRulesets() {
+function getRulesetDirectory() {
+  return fileURLToPath(new URL("../.github/rulesets/", import.meta.url));
+}
+
+export function readLocalRulesets() {
+  const rulesetDirectory = getRulesetDirectory();
   return readdirSync(rulesetDirectory)
     .filter((file) => file.endsWith(".json"))
     .map((file) => {
@@ -84,7 +100,7 @@ function readLocalRulesets() {
     });
 }
 
-async function githubApi(pathname) {
+export async function githubApi(pathname) {
   const response = await globalThis.fetch(`${apiBaseUrl}${pathname}`, {
     headers: {
       Accept: "application/vnd.github+json",
@@ -99,7 +115,7 @@ async function githubApi(pathname) {
   return response.json();
 }
 
-async function readRemoteRulesets() {
+export async function readRemoteRulesets() {
   const summaries = await githubApi(
     `/repos/${repo}/rulesets?per_page=100&includes_parents=false`,
   );
@@ -115,11 +131,16 @@ function stringify(value) {
   return JSON.stringify(value, null, 2);
 }
 
-if (!repo) {
-  fail("GITHUB_REPOSITORY is required, for example Wfrm-Qz/sekiei.");
-} else if (!token) {
-  fail("GITHUB_TOKEN or GH_TOKEN is required.");
-} else {
+export async function runRulesetCheck() {
+  if (!repo) {
+    fail("GITHUB_REPOSITORY is required, for example Wfrm-Qz/sekiei.");
+    return;
+  }
+  if (!token) {
+    fail("GITHUB_TOKEN or GH_TOKEN is required.");
+    return;
+  }
+
   try {
     const localRulesets = readLocalRulesets();
     const remoteRulesets = await readRemoteRulesets();
@@ -154,7 +175,7 @@ if (!repo) {
       if (!expectedNames.has(remoteName)) {
         console.warn(
           `[ruleset-check] remote ruleset "${remoteName}" has no local file under ${basename(
-            rulesetDirectory,
+            getRulesetDirectory(),
           )}/.`,
         );
       }
@@ -168,4 +189,8 @@ if (!repo) {
   } catch (error) {
     fail(error instanceof Error ? error.message : String(error));
   }
+}
+
+if (process.argv[1] === currentFilePath) {
+  await runRulesetCheck();
 }

--- a/src/data/presets/README.md
+++ b/src/data/presets/README.md
@@ -1,0 +1,20 @@
+# Preset Data License
+
+The JSON preset files in this directory are licensed under the
+[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+This license notice applies to Sekiei's curated preset dataset as arranged and
+expressed in these JSON files. It does not claim new rights over natural facts,
+factual measurements, or third-party source materials.
+
+When reusing or modifying preset data, retain the source reference information
+for each reused preset. The reference information is provided in:
+
+- each preset's `parameters.metadata.fullReference`
+- [`../../../reference.md`](../../../reference.md)
+
+Attribution to Sekiei or Wfrm-Qz is appreciated, but not required. The required
+attribution is the preservation of the per-preset source references.
+
+If you modify preset data, indicate that the data was changed where reasonably
+practicable.

--- a/tests/unit/data/licenses.test.ts
+++ b/tests/unit/data/licenses.test.ts
@@ -12,10 +12,33 @@ function readJson(path: string) {
 }
 
 describe("third-party license inventory", () => {
-  it("declares the project license as MIT and keeps a root LICENSE file", () => {
+  it("declares the package license expression and keeps project license files", () => {
     const packageJson = readJson(PACKAGE_JSON_PATH);
-    expect(packageJson.license).toBe("MIT");
+    expect(packageJson.license).toBe("MIT AND CC-BY-4.0");
     expect(existsSync(resolve(ROOT_DIR, "LICENSE"))).toBe(true);
+    expect(existsSync(resolve(ROOT_DIR, "docs/licensing.md"))).toBe(true);
+    expect(existsSync(resolve(ROOT_DIR, "src/data/presets/README.md"))).toBe(
+      true,
+    );
+  });
+
+  it("documents preset data attribution through source references", () => {
+    const presetLicense = readFileSync(
+      resolve(ROOT_DIR, "src/data/presets/README.md"),
+      "utf8",
+    );
+    const licensingDoc = readFileSync(
+      resolve(ROOT_DIR, "docs/licensing.md"),
+      "utf8",
+    );
+
+    [presetLicense, licensingDoc].forEach((text) => {
+      expect(text).toContain("Creative Commons Attribution 4.0");
+      expect(text).toContain("parameters.metadata.fullReference");
+      expect(text).toContain("reference.md");
+      expect(text).toContain("Attribution to Sekiei or Wfrm-Qz is appreciated");
+      expect(text).toContain("not required");
+    });
   });
 
   it("tracks expected licenses for direct runtime dependencies", () => {

--- a/tests/unit/scripts/checkRulesets.test.ts
+++ b/tests/unit/scripts/checkRulesets.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeRule } from "../../../scripts/check-rulesets.mjs";
+
+describe("normalizeRule", () => {
+  it("treats GitHub API default empty required_reviewers as omitted", () => {
+    const localRule = normalizeRule({
+      type: "pull_request",
+      parameters: {
+        required_approving_review_count: 1,
+        dismiss_stale_reviews_on_push: true,
+        require_code_owner_review: true,
+        require_last_push_approval: true,
+        required_review_thread_resolution: true,
+        allowed_merge_methods: ["squash", "merge", "rebase"],
+      },
+    });
+    const remoteRule = normalizeRule({
+      type: "pull_request",
+      parameters: {
+        required_approving_review_count: 1,
+        dismiss_stale_reviews_on_push: true,
+        required_reviewers: [],
+        require_code_owner_review: true,
+        require_last_push_approval: true,
+        required_review_thread_resolution: true,
+        allowed_merge_methods: ["merge", "rebase", "squash"],
+      },
+    });
+
+    expect(remoteRule).toEqual(localRule);
+  });
+
+  it("keeps non-empty required_reviewers for drift detection", () => {
+    const normalized = normalizeRule({
+      type: "pull_request",
+      parameters: {
+        required_reviewers: [
+          {
+            repository_role_name: "maintain",
+            reviewer_id: 2,
+            reviewer_type: "RepositoryRole",
+          },
+        ],
+      },
+    });
+
+    expect(normalized).toEqual({
+      type: "pull_request",
+      parameters: {
+        required_reviewers: [
+          {
+            repository_role_name: "maintain",
+            reviewer_id: 2,
+            reviewer_type: "RepositoryRole",
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## 概要

`develop` に入っている運用・ライセンス文書更新を `master` へ反映します。

含まれる主な変更:

- Ruleset Drift の比較で、GitHub API が補う空の `required_reviewers` を未指定と同等に扱うよう修正
- Ruleset 比較ロジックの回帰テストを追加
- アプリ本体・プロジェクト文書は MIT、`src/data/presets/` のプリセットデータは CC BY 4.0 としてライセンス境界を明記
- プリセットデータの流用・改変時は、Sekiei / Wfrm-Qz への帰属表示ではなく、各プリセットの `metadata.fullReference` または `reference.md` の出典表記を引き継ぐ方針を文書化
- ライセンス文書と出典継承の記載を unit test で固定

## 確認

- 各 issue branch の GitHub Actions `CI` 成功
- `develop` 上のPRマージ済み

Closes #1
Closes #3