### PR TITLE
お知らせ更新日の回帰テストを追加する

### DIFF
--- a/src/content/announcements.ts
+++ b/src/content/announcements.ts
@@ -34,7 +34,9 @@ function createAnnouncementMarkdownError(
   lineNumber: number,
   message: string,
 ) {
-  return new Error(`[announcement markdown:${sourceName}:${lineNumber}] ${message}`);
+  return new Error(
+    `[announcement markdown:${sourceName}:${lineNumber}] ${message}`,
+  );
 }
 
 function stripMarkdownComments(markdown: string) {
@@ -91,7 +93,9 @@ function finalizeParsedAnnouncementSection(
 }
 
 function parseAnnouncementSections(markdown: string, sourceName: string) {
-  const lines = stripMarkdownComments(markdown).replace(/\r\n?/g, "\n").split("\n");
+  const lines = stripMarkdownComments(markdown)
+    .replace(/\r\n?/g, "\n")
+    .split("\n");
   const sections: ParsedAnnouncementSection[] = [];
   let currentSection: ParsedAnnouncementSection | null = null;
   let currentLocale: SupportedLocale | null = null;
@@ -197,7 +201,7 @@ export function parseAnnouncementKnownIssuesMarkdown(
 export const ANNOUNCEMENTS: readonly AnnouncementEntry[] = [
   {
     id: "2026-04-26-notice-board",
-    updatedAt: "2026-04-27T00:10:00+09:00",
+    updatedAt: "2026-04-27",
     history: parseAnnouncementHistoryMarkdown(changelogMarkdown),
     knownIssues: parseAnnouncementKnownIssuesMarkdown(knownIssuesMarkdown),
     links: {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,7 +1,21 @@
 import { expect, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
-const ANNOUNCEMENT_REVISION =
-  "2026-04-26-notice-board::2026-04-27T00:10:00+09:00";
+function resolveLatestAnnouncementRevision() {
+  const source = readFileSync(
+    resolve(process.cwd(), "src/content/announcements.ts"),
+    "utf8",
+  );
+  const id = source.match(/\bid:\s*"([^"]+)"/)?.[1];
+  const updatedAt = source.match(/\bupdatedAt:\s*"([^"]+)"/)?.[1];
+  if (!id || !updatedAt) {
+    throw new Error("Could not resolve latest announcement revision for E2E.");
+  }
+  return `${id}::${updatedAt}`;
+}
+
+const ANNOUNCEMENT_REVISION = resolveLatestAnnouncementRevision();
 
 /**
  * E2E では本筋と無関係な起動時お知らせを既読扱いにして、主要フローへすぐ入る。

--- a/tests/unit/data/announcements.test.ts
+++ b/tests/unit/data/announcements.test.ts
@@ -77,4 +77,20 @@ describe("content/announcements", () => {
     expect(latestAnnouncement?.history[0]?.version).toBe("v0.1.0");
     expect(latestAnnouncement?.knownIssues).toEqual([]);
   });
+
+  it("keeps the announcement updated date at least as new as the latest changelog entry", () => {
+    const latestAnnouncement = getLatestAnnouncement();
+
+    if (!latestAnnouncement) {
+      throw new Error("latest announcement is required for this test");
+    }
+    const latestHistoryDate = latestAnnouncement.history[0]?.date;
+    if (!latestHistoryDate) {
+      throw new Error("latest announcement history is required for this test");
+    }
+
+    expect(
+      new Date(latestAnnouncement.updatedAt).getTime(),
+    ).toBeGreaterThanOrEqual(new Date(latestHistoryDate).getTime());
+  });
 });


### PR DESCRIPTION
## 概要

- お知らせの `updatedAt` を日付のみの `2026-04-27` に更新しました。
- タイムゾーン付き日時がUTC整形で前日に見える問題を避けます。
- `updatedAt` が最新の更新履歴日付より古くならないことを unit test で固定しました。

## 確認

- `npm run test:unit -- tests/unit/data/announcements.test.ts`
- `npm run lint:changed`
- `npm run build`
- push時 pre-push の `npm run public:check`

Closes #6