### PR TITLE
Issue起点の作業ルールを明記する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,16 @@
 - Playwright の E2E spec は `tests/e2e/` に置きます。
 - `docs/testing.md` が公開向けのテスト説明の正本です。旧 `docs/TEST-RUNNING.md` 前提では扱いません。
 
+## Issue 起点の作業
+
+- Sekiei の修正作業では、原則として実装・ドキュメント編集に入る前に GitHub Issue を作成します。
+- Issue 作成後、その Issue 番号に対応する `issue/*` ブランチを作って作業します。
+  - 例: `issue/12-fix-announcement-date`
+- Pull request は通常 `issue/* -> develop` で作成します。
+- `develop -> master` は公開反映用の PR として分けます。
+- 既に該当 Issue がある場合は、その Issue を使います。
+- ユーザーが明示的に Issue 不要、または直接作業を指示した場合だけ、この手順を省略してよいです。
+
 ## ライセンスと同梱資産
 
 - 第三者依存と bundled font の公開向け整理は `LICENSES.md` を正とします。


### PR DESCRIPTION
## 概要

- `AGENTS.md` に、Sekiei の修正作業は原則 Issue 作成から始めることを明記しました。
- Issue番号に対応する `issue/*` ブランチで作業し、通常は `issue/* -> develop` の PR にする運用を明記しました。
- `develop -> master` は公開反映用PRとして分けることも明記しました。
- 例外は、ユーザーが明示的に Issue 不要または直接作業を指示した場合だけにしています。

## ローカルskill更新

Git管理外の workspace skill 5件にも同じ Issue 起点ルールを追記済みです。

- `crystralmaker-i18n-ui-sync`
- `crystralmaker-preset-json`
- `crystralmaker-public-docs-license`
- `crystralmaker-spec-log-sync`
- `crystralmaker-twin-preview`

## 確認

- `npm run lint:changed`
- push時 pre-push の `npm run public:check`

Closes #9