### PR TITLE
プリセット出典に結晶学情報を追加する

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -23,6 +23,8 @@
 - cerussite-00001
   - Face
     - Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)
+  - Crystallography
+    - RRUFF(R060017)
 - corundum-00001
   - Face
     - Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)
@@ -50,15 +52,21 @@
 - hematite-00001
   - Face
     - Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)
+  - Crystallography
+    - American Mineralogist 97 (2012) 1808-1811 (via RRUFF)
 - hexagonal-prism-00001
   - Face
     - 外部出典なし（基本形状プリセット）
 - microcline-00001
   - Face
     - Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)
+  - Crystallography
+    - European Journal of Mineralogy 20 (2008) 635-651 (via RRUFF)
 - microcline-00002
   - Face
     - Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)
+  - Crystallography
+    - European Journal of Mineralogy 20 (2008) 635-651 (via RRUFF)
 - octahedron-00001
   - Face
     - 外部出典なし（基本形状プリセット）
@@ -85,6 +93,8 @@
 - smithsonite-00001
   - Face
     - Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)
+  - Crystallography
+    - RRUFF(R040051)
 - sphalerite-00001
   - Face
     - Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)

--- a/src/data/presets/cerussite-00001-T.json
+++ b/src/data/presets/cerussite-00001-T.json
@@ -12,7 +12,7 @@
       "shortDescription": "Sterling Hill",
       "description": "Plan of a crystal of cerussite like that of figure 63, twinned on the prism(110).",
       "reference": "Palache 1935",
-      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)"
+      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)\nCrystallography :RRUFF(R060017)"
     },
     "crystalSystem": "orthorhombic",
     "axes": {

--- a/src/data/presets/hematite-00001.json
+++ b/src/data/presets/hematite-00001.json
@@ -12,7 +12,7 @@
       "shortDescription": "Franklin",
       "description": "Pseudocubic crystal of hematite showing the rhombohedron.",
       "reference": "Palache 1935",
-      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)"
+      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)\nCrystallography :American Mineralogist 97  (2012) 1808-1811 (via RRUFF)"
     },
     "crystalSystem": "trigonal",
     "axes": {

--- a/src/data/presets/microcline-00001.json
+++ b/src/data/presets/microcline-00001.json
@@ -12,7 +12,7 @@
       "shortDescription": "Trotter mine",
       "description": "?",
       "reference": "Palache 1935",
-      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)"
+      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)\nCrystallography :European Journal of Mineralogy 20  (2008) 635-651 (via RRUFF)"
     },
     "crystalSystem": "triclinic",
     "axes": {

--- a/src/data/presets/microcline-00002.json
+++ b/src/data/presets/microcline-00002.json
@@ -12,7 +12,7 @@
       "shortDescription": "Trotter mine",
       "description": "?",
       "reference": "Palache 1935",
-      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)"
+      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)\nCrystallography :European Journal of Mineralogy 20  (2008) 635-651 (via RRUFF)"
     },
     "crystalSystem": "triclinic",
     "axes": {

--- a/src/data/presets/smithsonite-00001.json
+++ b/src/data/presets/smithsonite-00001.json
@@ -12,7 +12,7 @@
       "shortDescription": "Franklin",
       "description": "Prismatic crystal of smithsonite showing the forms m(10-10),\nf(02-21). and v(21-31).",
       "reference": "Palache 1935",
-      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)"
+      "fullReference": "Charles Palache, The minerals of Franklin and Sterling Hill, Sussex County, New Jersey (USGS Professional Paper 180, 1935)\nCrystallography :RRUFF(R040051)"
     },
     "crystalSystem": "trigonal",
     "axes": {

--- a/tests/unit/data/jsonSchemaDocuments.test.ts
+++ b/tests/unit/data/jsonSchemaDocuments.test.ts
@@ -28,6 +28,12 @@ const PRESET_JSON_PATHS = readdirSync(
 const PRESET_FILE_NAME_PATTERN =
   /^([a-z0-9]+(?:-[a-z0-9]+)*-\d{5})(?:-[A-Za-z0-9][A-Za-z0-9-]*)?\.json$/;
 
+const BASIC_SHAPE_PRESET_IDS = new Set([
+  "cube-00001",
+  "hexagonal-prism-00001",
+  "octahedron-00001",
+]);
+
 const SAMPLE_JSON_PATHS = [
   "docs/samples/cube.json",
   "docs/samples/cube-text.json",
@@ -97,6 +103,30 @@ describe("data/json schema documents", () => {
     "built-in preset %s は現行 wrapper schema に一致する",
     (relativePath) => {
       expectValidWrapperDocument(relativePath);
+    },
+  );
+
+  it.each(PRESET_JSON_PATHS)(
+    "built-in preset %s は非立方晶系・基本立体以外で Crystallography 出典を持つ",
+    (relativePath) => {
+      const document = loadJsonDocument(relativePath);
+
+      if (!isTwinPreviewSettingsDocument(document)) {
+        return;
+      }
+
+      const parameters = document.parameters;
+      if (
+        parameters.crystalSystem === "cubic" ||
+        BASIC_SHAPE_PRESET_IDS.has(parameters.presetId)
+      ) {
+        return;
+      }
+
+      expect(
+        String(parameters.metadata?.fullReference ?? ""),
+        `${relativePath} should include a Crystallography source in metadata.fullReference`,
+      ).toMatch(/\bCrystallography\b/);
     },
   );
 


### PR DESCRIPTION
## Summary
- Add missing Crystallography references to non-cubic built-in presets sourced from `C:\work\Crystaldata\preset`.
- Update `reference.md` with the same crystallography sources.
- Add a regression test requiring non-cubic, non-basic-shape built-in presets to include a Crystallography source in `metadata.fullReference`.

## Tests
- `npm run test:unit -- tests/unit/data/jsonSchemaDocuments.test.ts tests/unit/data/presets.test.ts`
- `npm run lint:changed`
- pre-push `npm run public:check`

Closes #30